### PR TITLE
Release derivatives-trading-usds-futures v1.0.1

### DIFF
--- a/clients/derivatives-trading-usds-futures/CHANGELOG.md
+++ b/clients/derivatives-trading-usds-futures/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - 2025-04-07
+
+- Update `@binance/common` library to version `1.0.1`.
+
 ## 1.0.0 - 2025-03-24
 
-Initial release
+- Initial release

--- a/clients/derivatives-trading-usds-futures/package-lock.json
+++ b/clients/derivatives-trading-usds-futures/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-usds-futures",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-usds-futures",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.0",
+                "@binance/common": "1.0.1",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
             },
@@ -22,7 +22,7 @@
                 "prettier": "^3.3.3",
                 "ts-jest": "^29.1.1",
                 "ts-node": "^10.9.1",
-                "tsup": "^7.2.0",
+                "tsup": "^8.4.0",
                 "typescript": "^5.7.2",
                 "typescript-eslint": "^8.24.0"
             }
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.0.tgz",
-            "integrity": "sha512-JVESKj7SNfETIWTGmnitItyCpGJkDnILN1PlLuqhrUfuU9pd7iN9MUWuz7tnihqFvTEXltXVjPaJexLm4xXHqw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.1.tgz",
+            "integrity": "sha512-IhhA5xPITDQX4GrzdKMiaFwvD73D7IEhNh1DOJWqyut3mBFW9gaKnUEgdejYTeoqOuQMZEqSQHoONCf5IaZfog==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",
@@ -571,10 +571,27 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+            "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+            "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
             "cpu": [
                 "arm"
             ],
@@ -585,13 +602,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+            "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
             "cpu": [
                 "arm64"
             ],
@@ -602,13 +619,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+            "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
             "cpu": [
                 "x64"
             ],
@@ -619,13 +636,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+            "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
             "cpu": [
                 "arm64"
             ],
@@ -636,13 +653,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+            "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
             "cpu": [
                 "x64"
             ],
@@ -653,13 +670,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
             "cpu": [
                 "arm64"
             ],
@@ -670,13 +687,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+            "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
             "cpu": [
                 "x64"
             ],
@@ -687,13 +704,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+            "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
             "cpu": [
                 "arm"
             ],
@@ -704,13 +721,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+            "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
             "cpu": [
                 "arm64"
             ],
@@ -721,13 +738,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+            "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
             "cpu": [
                 "ia32"
             ],
@@ -738,13 +755,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+            "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
             "cpu": [
                 "loong64"
             ],
@@ -755,13 +772,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+            "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
             "cpu": [
                 "mips64el"
             ],
@@ -772,13 +789,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+            "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
             "cpu": [
                 "ppc64"
             ],
@@ -789,13 +806,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+            "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
             "cpu": [
                 "riscv64"
             ],
@@ -806,13 +823,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+            "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
             "cpu": [
                 "s390x"
             ],
@@ -823,13 +840,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+            "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
             "cpu": [
                 "x64"
             ],
@@ -840,13 +857,30 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
             "cpu": [
                 "x64"
             ],
@@ -857,13 +891,30 @@
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
             "cpu": [
                 "x64"
             ],
@@ -874,13 +925,13 @@
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+            "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
             "cpu": [
                 "x64"
             ],
@@ -891,13 +942,13 @@
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+            "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -908,13 +959,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+            "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
             "cpu": [
                 "ia32"
             ],
@@ -925,13 +976,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+            "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
             "cpu": [
                 "x64"
             ],
@@ -942,7 +993,7 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -1660,6 +1711,286 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.39.0.tgz",
+            "integrity": "sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.39.0.tgz",
+            "integrity": "sha512-It9+M1zE31KWfqh/0cJLrrsCPiF72PoJjIChLX+rEcujVRCb4NLQ5QzFkzIZW8Kn8FTbvGQBY5TkKBau3S8cCQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.39.0.tgz",
+            "integrity": "sha512-lXQnhpFDOKDXiGxsU9/l8UEGGM65comrQuZ+lDcGUx+9YQ9dKpF3rSEGepyeR5AHZ0b5RgiligsBhWZfSSQh8Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.39.0.tgz",
+            "integrity": "sha512-mKXpNZLvtEbgu6WCkNij7CGycdw9cJi2k9v0noMb++Vab12GZjFgUXD69ilAbBh034Zwn95c2PNSz9xM7KYEAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.39.0.tgz",
+            "integrity": "sha512-jivRRlh2Lod/KvDZx2zUR+I4iBfHcu2V/BA2vasUtdtTN2Uk3jfcZczLa81ESHZHPHy4ih3T/W5rPFZ/hX7RtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.39.0.tgz",
+            "integrity": "sha512-8RXIWvYIRK9nO+bhVz8DwLBepcptw633gv/QT4015CpJ0Ht8punmoHU/DuEd3iw9Hr8UwUV+t+VNNuZIWYeY7Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.39.0.tgz",
+            "integrity": "sha512-mz5POx5Zu58f2xAG5RaRRhp3IZDK7zXGk5sdEDj4o96HeaXhlUwmLFzNlc4hCQi5sGdR12VDgEUqVSHer0lI9g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.39.0.tgz",
+            "integrity": "sha512-+YDwhM6gUAyakl0CD+bMFpdmwIoRDzZYaTWV3SDRBGkMU/VpIBYXXEvkEcTagw/7VVkL2vA29zU4UVy1mP0/Yw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.39.0.tgz",
+            "integrity": "sha512-EKf7iF7aK36eEChvlgxGnk7pdJfzfQbNvGV/+l98iiMwU23MwvmV0Ty3pJ0p5WQfm3JRHOytSIqD9LB7Bq7xdQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.39.0.tgz",
+            "integrity": "sha512-vYanR6MtqC7Z2SNr8gzVnzUul09Wi1kZqJaek3KcIlI/wq5Xtq4ZPIZ0Mr/st/sv/NnaPwy/D4yXg5x0B3aUUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.39.0.tgz",
+            "integrity": "sha512-NMRUT40+h0FBa5fb+cpxtZoGAggRem16ocVKIv5gDB5uLDgBIwrIsXlGqYbLwW8YyO3WVTk1FkFDjMETYlDqiw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.39.0.tgz",
+            "integrity": "sha512-0pCNnmxgduJ3YRt+D+kJ6Ai/r+TaePu9ZLENl+ZDV/CdVczXl95CbIiwwswu4L+K7uOIGf6tMo2vm8uadRaICQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.39.0.tgz",
+            "integrity": "sha512-t7j5Zhr7S4bBtksT73bO6c3Qa2AV/HqiGlj9+KB3gNF5upcVkx+HLgxTm8DK4OkzsOYqbdqbLKwvGMhylJCPhQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.39.0.tgz",
+            "integrity": "sha512-m6cwI86IvQ7M93MQ2RF5SP8tUjD39Y7rjb1qjHgYh28uAPVU8+k/xYWvxRO3/tBN2pZkSMa5RjnPuUIbrwVxeA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.39.0.tgz",
+            "integrity": "sha512-iRDJd2ebMunnk2rsSBYlsptCyuINvxUfGwOUldjv5M4tpa93K8tFMeYGpNk2+Nxl+OBJnBzy2/JCscGeO507kA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.39.0.tgz",
+            "integrity": "sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.39.0.tgz",
+            "integrity": "sha512-ThFdkrFDP55AIsIZDKSBWEt/JcWlCzydbZHinZ0F/r1h83qbGeenCt/G/wG2O0reuENDD2tawfAj2s8VK7Bugg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.39.0.tgz",
+            "integrity": "sha512-jDrLm6yUtbOg2TYB3sBF3acUnAwsIksEYjLeHL+TJv9jg+TmTwdyjnDex27jqEMakNKf3RwwPahDIt7QXCSqRQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.39.0.tgz",
+            "integrity": "sha512-6w9uMuza+LbLCVoNKL5FSLE7yvYkq9laSd09bwS0tMjkwXrmib/4KmoJcrKhLWHvw19mwU+33ndC69T7weNNjQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.39.0.tgz",
+            "integrity": "sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1759,6 +2090,13 @@
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
@@ -2234,16 +2572,6 @@
             "dev": true,
             "license": "Python-2.0"
         },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/async": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2391,19 +2719,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/binary-extensions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2492,9 +2807,9 @@
             "license": "MIT"
         },
         "node_modules/bundle-require": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.2.1.tgz",
-            "integrity": "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+            "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2504,7 +2819,7 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "peerDependencies": {
-                "esbuild": ">=0.17"
+                "esbuild": ">=0.18"
             }
         },
         "node_modules/cac": {
@@ -2599,41 +2914,19 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^4.0.1"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 14.16.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/chokidar/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/ci-info": {
@@ -2740,6 +3033,16 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -2881,19 +3184,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3027,9 +3317,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+            "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -3037,31 +3327,34 @@
                 "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.25.2",
+                "@esbuild/android-arm": "0.25.2",
+                "@esbuild/android-arm64": "0.25.2",
+                "@esbuild/android-x64": "0.25.2",
+                "@esbuild/darwin-arm64": "0.25.2",
+                "@esbuild/darwin-x64": "0.25.2",
+                "@esbuild/freebsd-arm64": "0.25.2",
+                "@esbuild/freebsd-x64": "0.25.2",
+                "@esbuild/linux-arm": "0.25.2",
+                "@esbuild/linux-arm64": "0.25.2",
+                "@esbuild/linux-ia32": "0.25.2",
+                "@esbuild/linux-loong64": "0.25.2",
+                "@esbuild/linux-mips64el": "0.25.2",
+                "@esbuild/linux-ppc64": "0.25.2",
+                "@esbuild/linux-riscv64": "0.25.2",
+                "@esbuild/linux-s390x": "0.25.2",
+                "@esbuild/linux-x64": "0.25.2",
+                "@esbuild/netbsd-arm64": "0.25.2",
+                "@esbuild/netbsd-x64": "0.25.2",
+                "@esbuild/openbsd-arm64": "0.25.2",
+                "@esbuild/openbsd-x64": "0.25.2",
+                "@esbuild/sunos-x64": "0.25.2",
+                "@esbuild/win32-arm64": "0.25.2",
+                "@esbuild/win32-ia32": "0.25.2",
+                "@esbuild/win32-x64": "0.25.2"
             }
         },
         "node_modules/escalade": {
@@ -3698,27 +3991,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3893,19 +4165,6 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -5325,16 +5584,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5435,9 +5684,9 @@
             }
         },
         "node_modules/postcss-load-config": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-            "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+            "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
             "dev": true,
             "funding": [
                 {
@@ -5451,21 +5700,28 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "lilconfig": "^3.0.0",
-                "yaml": "^2.3.4"
+                "lilconfig": "^3.1.1"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             },
             "peerDependencies": {
+                "jiti": ">=1.21.0",
                 "postcss": ">=8.0.9",
-                "ts-node": ">=9.0.0"
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                },
                 "postcss": {
                     "optional": true
                 },
-                "ts-node": {
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
                     "optional": true
                 }
             }
@@ -5600,16 +5856,17 @@
             "license": "MIT"
         },
         "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/require-directory": {
@@ -5715,19 +5972,42 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.29.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-            "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+            "version": "4.39.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.39.0.tgz",
+            "integrity": "sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.7"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.39.0",
+                "@rollup/rollup-android-arm64": "4.39.0",
+                "@rollup/rollup-darwin-arm64": "4.39.0",
+                "@rollup/rollup-darwin-x64": "4.39.0",
+                "@rollup/rollup-freebsd-arm64": "4.39.0",
+                "@rollup/rollup-freebsd-x64": "4.39.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.39.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.39.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.39.0",
+                "@rollup/rollup-linux-arm64-musl": "4.39.0",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.39.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.39.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.39.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.39.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.39.0",
+                "@rollup/rollup-linux-x64-gnu": "4.39.0",
+                "@rollup/rollup-linux-x64-musl": "4.39.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.39.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.39.0",
+                "@rollup/rollup-win32-x64-msvc": "4.39.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6109,6 +6389,58 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.4.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6276,25 +6608,27 @@
             }
         },
         "node_modules/tsup": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/tsup/-/tsup-7.2.0.tgz",
-            "integrity": "sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.4.0.tgz",
+            "integrity": "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "bundle-require": "^4.0.0",
-                "cac": "^6.7.12",
-                "chokidar": "^3.5.1",
-                "debug": "^4.3.1",
-                "esbuild": "^0.18.2",
-                "execa": "^5.0.0",
-                "globby": "^11.0.3",
-                "joycon": "^3.0.1",
-                "postcss-load-config": "^4.0.1",
+                "bundle-require": "^5.1.0",
+                "cac": "^6.7.14",
+                "chokidar": "^4.0.3",
+                "consola": "^3.4.0",
+                "debug": "^4.4.0",
+                "esbuild": "^0.25.0",
+                "joycon": "^3.1.1",
+                "picocolors": "^1.1.1",
+                "postcss-load-config": "^6.0.1",
                 "resolve-from": "^5.0.0",
-                "rollup": "^3.2.5",
+                "rollup": "^4.34.8",
                 "source-map": "0.8.0-beta.0",
-                "sucrase": "^3.20.3",
+                "sucrase": "^3.35.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.11",
                 "tree-kill": "^1.2.2"
             },
             "bin": {
@@ -6302,14 +6636,18 @@
                 "tsup-node": "dist/cli-node.js"
             },
             "engines": {
-                "node": ">=16.14"
+                "node": ">=18"
             },
             "peerDependencies": {
+                "@microsoft/api-extractor": "^7.36.0",
                 "@swc/core": "^1",
                 "postcss": "^8.4.12",
-                "typescript": ">=4.1.0"
+                "typescript": ">=4.5.0"
             },
             "peerDependenciesMeta": {
+                "@microsoft/api-extractor": {
+                    "optional": true
+                },
                 "@swc/core": {
                     "optional": true
                 },
@@ -6637,19 +6975,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/clients/derivatives-trading-usds-futures/package.json
+++ b/clients/derivatives-trading-usds-futures/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-usds-futures",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -40,12 +40,12 @@
         "prettier": "^3.3.3",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
-        "tsup": "^7.2.0",
+        "tsup": "^8.4.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.0.0",
+        "@binance/common": "1.0.1",
         "axios": "^1.7.4",
         "ws": "^8.17.1"
     }

--- a/clients/derivatives-trading-usds-futures/src/rest-api/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/account-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/account-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/convert-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/convert-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/market-data-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/market-data-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/portfolio-margin-endpoints-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/portfolio-margin-endpoints-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/trade-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/user-data-streams-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/user-data-streams-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/rest-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/rest-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/accept-the-offered-quote-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/accept-the-offered-quote-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1-positions-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1-positions-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response2-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response2-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v2-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1-positions-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1-positions-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-information-v3-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-trade-list-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-trade-list-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/account-trade-list-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/account-trade-list-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/all-orders-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/all-orders-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/all-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/all-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/auto-cancel-all-open-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/auto-cancel-all-open-orders-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/bad-request.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/bad-request.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/basis-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/basis-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/basis-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/basis-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-all-open-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-all-open-orders-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-multiple-orders-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-multiple-orders-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-multiple-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-multiple-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/cancel-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/change-initial-leverage-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/change-initial-leverage-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/change-margin-type-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/change-margin-type-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/change-multi-assets-mode-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/change-multi-assets-mode-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/change-position-mode-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/change-position-mode-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/check-server-time-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/check-server-time-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/classic-portfolio-margin-account-information-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/classic-portfolio-margin-account-information-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response-inner-base-asset-list-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response-inner-base-asset-list-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response-inner.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/composite-index-symbol-information-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/compressed-aggregate-trades-list-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/compressed-aggregate-trades-list-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/compressed-aggregate-trades-list-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/compressed-aggregate-trades-list-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/continuous-contract-kline-candlestick-data-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/current-all-open-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/current-all-open-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner-filters-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner-filters-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v2-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v2-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v2-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v3-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-balance-v3-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-configuration-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-account-configuration-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1-indicators-btcusdtinner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1-indicators-btcusdtinner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1-indicators.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1-indicators.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2-indicators-accountinner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2-indicators-accountinner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2-indicators.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2-indicators.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/futures-trading-quantitative-rules-indicators-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-bnb-burn-status-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-bnb-burn-status-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-current-multi-assets-mode-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-current-multi-assets-mode-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-current-position-mode-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-current-position-mode-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-order-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-order-history-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-trade-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-trade-history-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-transaction-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-download-id-for-futures-transaction-history-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-history-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-history-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-history-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-info-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-info-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-info-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-funding-rate-info-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-order-history-download-link-by-id-response2.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-trade-download-link-by-id-response2.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-futures-transaction-history-download-link-by-id-response2.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-income-history-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-income-history-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-income-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-income-history-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment-orig-qty.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment-orig-qty.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment-price.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment-price.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner-amendment.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response-inner.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-order-modify-history-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-position-margin-change-history-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-position-margin-change-history-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/get-position-margin-change-history-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/get-position-margin-change-history-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/historical-blvt-nav-kline-candlestick-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/index-price-kline-candlestick-data-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/keepalive-user-data-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/keepalive-user-data-stream-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/kline-candlestick-data-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/list-all-convert-pairs-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/list-all-convert-pairs-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/list-all-convert-pairs-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/list-all-convert-pairs-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/long-short-ratio-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/long-short-ratio-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/long-short-ratio-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/long-short-ratio-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-kline-candlestick-data-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/mark-price-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-isolated-position-margin-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-isolated-position-margin-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-batch-orders-parameter-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-batch-orders-parameter-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-multiple-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/modify-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/multi-assets-mode-asset-index-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/new-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/new-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1-inner-brackets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1-inner-brackets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1-inner.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/notional-and-leverage-brackets-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/old-trades-lookup-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/old-trades-lookup-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/old-trades-lookup-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/old-trades-lookup-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-statistics-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-statistics-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-statistics-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/open-interest-statistics-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response-asks-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response-asks-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response-bids-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response-bids-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/order-book-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/order-status-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/order-status-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/place-multiple-orders-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/place-multiple-orders-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/place-multiple-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/place-multiple-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response-inner-adl-quantile.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response-inner-adl-quantile.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response-inner.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-adl-quantile-estimation-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response1-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response1-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v2-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response1-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response1-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/position-information-v3-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response-item-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response-item-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/premium-index-kline-data-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/quarterly-contract-settlement-price-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/quarterly-contract-settlement-price-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/quarterly-contract-settlement-price-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/quarterly-contract-settlement-price-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-current-open-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-current-open-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-index-price-constituents-response-constituents-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-index-price-constituents-response-constituents-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-index-price-constituents-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-index-price-constituents-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-user-rate-limit-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-user-rate-limit-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/query-user-rate-limit-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/query-user-rate-limit-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/recent-trades-list-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/recent-trades-list-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/recent-trades-list-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/recent-trades-list-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/send-quote-request-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/send-quote-request-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/start-user-data-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/start-user-data-stream-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-configuration-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-configuration-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-configuration-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-configuration-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-order-book-ticker-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/symbol-price-ticker-v2-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/taker-buy-sell-volume-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/taker-buy-sell-volume-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/taker-buy-sell-volume-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/taker-buy-sell-volume-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/test-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/test-order-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response1.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response2-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response2-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/ticker24hr-price-change-statistics-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/toggle-bnb-burn-on-futures-trade-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/toggle-bnb-burn-on-futures-trade-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-accounts-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-accounts-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-accounts-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-accounts-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-positions-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-positions-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-positions-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/top-trader-long-short-ratio-positions-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/user-commission-rate-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/user-commission-rate-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/users-force-orders-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/users-force-orders-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/users-force-orders-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/users-force-orders-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/account-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/account-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/market-data-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/market-data-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/trade-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/user-data-streams-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/user-data-streams-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result-positions-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result-positions-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1-result.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2-result-positions-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2-result-positions-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2-result.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result-positions-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result-positions-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1-result.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2-result-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2-result-assets-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2-result.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/account-information-v2-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/cancel-order-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/close-user-data-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/close-user-data-stream-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-v2-response-result-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-v2-response-result-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/futures-account-balance-v2-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/keepalive-user-data-stream-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/keepalive-user-data-stream-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/keepalive-user-data-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/keepalive-user-data-stream-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/modify-order-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/new-order-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/new-order-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/new-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/new-order-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result-asks-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result-asks-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result-bids-item.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result-bids-item.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response-result.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/order-book-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response1-result-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response1-result-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response2-result-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response2-result-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response1-result-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response1-result-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response2-result-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response2-result-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/position-information-v2-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/query-order-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/query-order-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/query-order-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/query-order-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/start-user-data-stream-response-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/start-user-data-stream-response-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/start-user-data-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/start-user-data-stream-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1-rate-limits-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1-rate-limits-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-order-book-ticker-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response1-result.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response1-result.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response1.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response1.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response2.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/types/symbol-price-ticker-response2.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/websocket-api-connection.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/websocket-api-connection.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/websocket-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/websocket-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/modules/index.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/modules/index.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/modules/websocket-market-streams-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/modules/websocket-market-streams-api.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/aggregate-trade-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/aggregate-trade-streams-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-book-tickers-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-book-tickers-stream-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-liquidation-order-streams-response-o.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-liquidation-order-streams-response-o.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-liquidation-order-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-liquidation-order-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-mini-tickers-stream-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-mini-tickers-stream-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-mini-tickers-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-mini-tickers-stream-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-tickers-streams-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-tickers-streams-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-tickers-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/all-market-tickers-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/composite-index-symbol-information-streams-response-cinner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/composite-index-symbol-information-streams-response-cinner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/composite-index-symbol-information-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/composite-index-symbol-information-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/continuous-contract-kline-candlestick-streams-response-k.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/continuous-contract-kline-candlestick-streams-response-k.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/continuous-contract-kline-candlestick-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/continuous-contract-kline-candlestick-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/contract-info-stream-response-bks-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/contract-info-stream-response-bks-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/contract-info-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/contract-info-stream-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response-aitem.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response-aitem.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response-bitem.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response-bitem.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/diff-book-depth-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-book-ticker-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-book-ticker-streams-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-mini-ticker-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-mini-ticker-stream-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-ticker-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/individual-symbol-ticker-streams-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/kline-candlestick-streams-response-k.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/kline-candlestick-streams-response-k.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/kline-candlestick-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/kline-candlestick-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/liquidation-order-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/liquidation-order-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-for-all-market-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-for-all-market-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-for-all-market-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-for-all-market-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/mark-price-stream-response.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/multi-assets-mode-asset-index-response-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/multi-assets-mode-asset-index-response-inner.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/multi-assets-mode-asset-index-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/multi-assets-mode-asset-index-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response-aitem.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response-aitem.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response-bitem.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response-bitem.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/types/partial-book-depth-streams-response.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/websocket-streams-connection.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/websocket-streams-connection.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/src/websocket-streams/websocket-streams.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-streams/websocket-streams.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/AccountApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/AccountApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/ConvertApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/ConvertApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/MarketDataApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/MarketDataApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/PortfolioMarginEndpointsApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/PortfolioMarginEndpointsApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/TradeApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/TradeApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/UserDataStreamsApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/UserDataStreamsApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures REST API
+ * Binance Derivatives Trading USDS Futures REST API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures REST API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures REST API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/AccountApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/AccountApiTest.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/MarketDataApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/MarketDataApiTest.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/TradeApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/TradeApiTest.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/UserDataStreamsApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-api/UserDataStreamsApiTest.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket API
+ * Binance Derivatives Trading USDS Futures WebSocket API
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket API
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket API
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-streams/WebsocketMarketStreamsApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-streams/WebsocketMarketStreamsApiTest.test.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *

--- a/clients/derivatives-trading-usds-futures/tests/unit/websocket-streams/utils.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/websocket-streams/utils.ts
@@ -1,7 +1,7 @@
 /**
- * Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
- * OpenAPI Specification for the Binance Public Derivatives Trading USDS Futures WebSocket Market Streams
+ * OpenAPI Specification for the Binance Derivatives Trading USDS Futures WebSocket Market Streams
  *
  * The version of the OpenAPI document: 1.0.0
  *


### PR DESCRIPTION
- Update `@binance/common` library to version `1.0.1`.