### PR TITLE
Release common v1.0.2

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.2 - 2025-04-10
 
+### Changed
+
 - Update `replaceWebsocketStreamsPlaceholders` function to parse `updateSpeed` properly.
 
 ## 1.0.1 - 2025-04-07


### PR DESCRIPTION
### Changed

- Update `replaceWebsocketStreamsPlaceholders` function to parse `updateSpeed` properly.