### PR TITLE
Release types v1.0.2

### DIFF
--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2 - 2025-04-10
+
+### Changed
+
+- Update `@binance/common` library to version `1.0.2`.
+
 ## 1.0.1 - 2025-04-07
 
 - Update `@binance/common` library to version `1.0.1`.

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/types",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/types",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.1"
+                "@binance/common": "1.0.2"
             },
             "devDependencies": {
                 "@types/node": "^20.17.24",
@@ -19,9 +19,9 @@
             }
         },
         "node_modules/@binance/common": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.1.tgz",
-            "integrity": "sha512-IhhA5xPITDQX4GrzdKMiaFwvD73D7IEhNh1DOJWqyut3mBFW9gaKnUEgdejYTeoqOuQMZEqSQHoONCf5IaZfog==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.2.tgz",
+            "integrity": "sha512-xRh7b5PXWJcVLOwV8bz+GsGXHmayFhI63WNoDhgOOX/4VaIZu0yiTO2l92BxfxgCyP8HDnK/GsnheOoGSIc/Dw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/types/package.json
+++ b/types/package.json
@@ -1,8 +1,14 @@
 {
     "name": "@binance/types",
     "description": "Shared types for Binance connectors",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "require": "./dist/index.js",
+            "import": "./dist/index.mjs"
+        }
+    },
     "scripts": {
         "prepublishOnly": "npm run build",
         "build": "tsup",
@@ -27,6 +33,6 @@
         "typescript": "^5.7.2"
     },
     "dependencies": {
-        "@binance/common": "1.0.1"
+        "@binance/common": "1.0.2"
     }
 }


### PR DESCRIPTION
### Changed

- Update `@binance/common` library to version `1.0.2`.