### PR TITLE
Release simple-earn v3.0.0

### DIFF
--- a/clients/simple-earn/CHANGELOG.md
+++ b/clients/simple-earn/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0 - 2025-04-15
+
+### Changed
+
+- Added `current`, `size` and `recvWindow` parameters to `/sapi/v1/simple-earn/flexible/history/rewardsRecord`.
+
 ## 2.0.0 - 2025-04-10
 
 ### Changed

--- a/clients/simple-earn/package-lock.json
+++ b/clients/simple-earn/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/simple-earn",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/simple-earn",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "1.0.2",

--- a/clients/simple-earn/package.json
+++ b/clients/simple-earn/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/simple-earn",
     "description": "Official Binance Simple Earn Connector - A lightweight library that provides a convenient interface to Binance's Simple Earn REST API.",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/simple-earn/src/rest-api/modules/history-api.ts
+++ b/clients/simple-earn/src/rest-api/modules/history-api.ts
@@ -185,6 +185,9 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
          * @param {string} [asset]
          * @param {number} [startTime]
          * @param {number} [endTime]
+         * @param {number} [current] Currently querying the page. Start from 1. Default:1
+         * @param {number} [size] Default:10, Max:100
+         * @param {number} [recvWindow]
          *
          * @throws {RequiredError}
          */
@@ -193,7 +196,10 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
             productId?: string,
             asset?: string,
             startTime?: number,
-            endTime?: number
+            endTime?: number,
+            current?: number,
+            size?: number,
+            recvWindow?: number
         ): Promise<RequestArgs> => {
             // verify required parameter 'type' is not null or undefined
             assertParamExists('getFlexibleRewardsHistory', 'type', type);
@@ -218,6 +224,18 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
 
             if (type !== undefined && type !== null) {
                 localVarQueryParameter['type'] = type;
+            }
+
+            if (current !== undefined && current !== null) {
+                localVarQueryParameter['current'] = current;
+            }
+
+            if (size !== undefined && size !== null) {
+                localVarQueryParameter['size'] = size;
+            }
+
+            if (recvWindow !== undefined && recvWindow !== null) {
+                localVarQueryParameter['recvWindow'] = recvWindow;
             }
 
             let _timeUnit: TimeUnit | undefined;
@@ -899,6 +917,27 @@ export interface GetFlexibleRewardsHistoryRequest {
      * @memberof HistoryApiGetFlexibleRewardsHistory
      */
     readonly endTime?: number;
+
+    /**
+     * Currently querying the page. Start from 1. Default:1
+     * @type {number}
+     * @memberof HistoryApiGetFlexibleRewardsHistory
+     */
+    readonly current?: number;
+
+    /**
+     * Default:10, Max:100
+     * @type {number}
+     * @memberof HistoryApiGetFlexibleRewardsHistory
+     */
+    readonly size?: number;
+
+    /**
+     *
+     * @type {number}
+     * @memberof HistoryApiGetFlexibleRewardsHistory
+     */
+    readonly recvWindow?: number;
 }
 
 /**
@@ -1305,7 +1344,10 @@ export class HistoryApi implements HistoryApiInterface {
             requestParameters?.productId,
             requestParameters?.asset,
             requestParameters?.startTime,
-            requestParameters?.endTime
+            requestParameters?.endTime,
+            requestParameters?.current,
+            requestParameters?.size,
+            requestParameters?.recvWindow
         );
         return sendRequest<GetFlexibleRewardsHistoryResponse>(
             this.configuration,

--- a/clients/simple-earn/tests/unit/rest-api/HistoryApiTest.test.ts
+++ b/clients/simple-earn/tests/unit/rest-api/HistoryApiTest.test.ts
@@ -272,6 +272,9 @@ describe('HistoryApi', () => {
                 asset: 'asset_example',
                 startTime: 1623319461670,
                 endTime: 1641782889000,
+                current: 1,
+                size: 10,
+                recvWindow: 5000,
             };
 
             mockResponse = {


### PR DESCRIPTION

### Changed

- Added `current`, `size` and `recvWindow` parameters to `/sapi/v1/simple-earn/flexible/history/rewardsRecord`.