### PR TITLE
Release derivatives-trading-coin-futures v2.0.0

### DIFF
--- a/clients/derivatives-trading-coin-futures/src/rest-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-coin-futures/src/rest-api/modules/trade-api.ts
@@ -949,7 +949,7 @@ const TradeApiAxiosParamCreator = function (configuration: ConfigurationRestAPI)
          * @param {number} [stopPrice] Used with `STOP/STOP_MARKET` or `TAKE_PROFIT/TAKE_PROFIT_MARKET` orders.
          * @param {string} [closePosition] `true`, `false`；Close-All,used with `STOP_MARKET` or `TAKE_PROFIT_MARKET`.
          * @param {number} [activationPrice] Used with `TRAILING_STOP_MARKET` orders, default as the latest price(supporting different `workingType`)
-         * @param {number} [callbackRate] Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 5 where 1 for 1%
+         * @param {number} [callbackRate] Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 10 where 1 for 1%
          * @param {NewOrderWorkingTypeEnum} [workingType] stopPrice triggered by: "MARK_PRICE", "CONTRACT_PRICE". Default "CONTRACT_PRICE"
          * @param {string} [priceProtect] "TRUE" or "FALSE", default "FALSE". Used with `STOP/STOP_MARKET` or `TAKE_PROFIT/TAKE_PROFIT_MARKET` orders.
          * @param {NewOrderNewOrderRespTypeEnum} [newOrderRespType] "ACK", "RESULT", default "ACK"
@@ -2398,7 +2398,7 @@ export interface NewOrderRequest {
     readonly activationPrice?: number;
 
     /**
-     * Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 5 where 1 for 1%
+     * Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 10 where 1 for 1%
      * @type {number}
      * @memberof TradeApiNewOrder
      */

--- a/clients/derivatives-trading-coin-futures/src/websocket-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-coin-futures/src/websocket-api/modules/trade-api.ts
@@ -356,7 +356,7 @@ export interface NewOrderRequest {
     readonly activationPrice?: number;
 
     /**
-     * Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 5 where 1 for 1%
+     * Used with `TRAILING_STOP_MARKET` orders, min 0.1, max 10 where 1 for 1%
      * @type {number}
      * @memberof TradeApiNewOrder
      */


### PR DESCRIPTION
### Changed

- Update `@binance/common` library to version `1.0.2`.
- Update examples.

### Removed

- Remove unused error reponses.