### PR TITLE
Release derivatives-trading-portfolio-margin-pro v5.0.0

### DIFF
--- a/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
+++ b/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.0 - 2025-05-26
+
+### Changed (1)
+
+- `queryPortfolioMarginProBankruptcyLoanRepayHistory()` (`GET /sapi/v1/portfolio/pmLoan-history` has been updated to `GET /sapi/v1/portfolio/pmloan-history`)
+
 ## 4.0.0 - 2025-04-23
 
 ### Changed

--- a/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-portfolio-margin-pro",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "1.0.2",

--- a/clients/derivatives-trading-portfolio-margin-pro/package.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
+++ b/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
@@ -536,7 +536,7 @@ const AccountApiAxiosParamCreator = function (configuration: ConfigurationRestAP
             if ('timeUnit' in configuration) _timeUnit = configuration.timeUnit as TimeUnit;
 
             return {
-                endpoint: '/sapi/v1/portfolio/pmLoan-history',
+                endpoint: '/sapi/v1/portfolio/pmloan-history',
                 method: 'GET',
                 params: localVarQueryParameter,
                 timeUnit: _timeUnit,


### PR DESCRIPTION
### Changed (1)

- `queryPortfolioMarginProBankruptcyLoanRepayHistory()` (`GET /sapi/v1/portfolio/pmLoan-history` has been updated to `GET /sapi/v1/portfolio/pmloan-history`)