### PR TITLE
Release sub-account v6.0.0

### DIFF
--- a/clients/sub-account/CHANGELOG.md
+++ b/clients/sub-account/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.0.0 - 2025-05-26
+
+### Changed (1)
+
+- Modified parameter `ipAddress` for the following methods:
+  - `addIpRestrictionForSubAccountApiKey()` (`POST /sapi/v2/sub-account/subAccountApi/ipRestriction`)
+  - `deleteIpListForASubAccountApiKey()` (`DELETE /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList`)
+
 ## 5.0.0 - 2025-05-14
 
 ### Changed

--- a/clients/sub-account/examples/rest-api/ApiManagementApi/deleteIpListForASubAccountApiKey.ts
+++ b/clients/sub-account/examples/rest-api/ApiManagementApi/deleteIpListForASubAccountApiKey.ts
@@ -12,6 +12,7 @@ async function deleteIpListForASubAccountApiKey() {
         const response = await client.restAPI.deleteIpListForASubAccountApiKey({
             email: 'sub-account-email@email.com',
             subAccountApiKey: 'subAccountApiKey_example',
+            ipAddress: 'ipAddress_example',
         });
 
         const rateLimits = response.rateLimits!;

--- a/clients/sub-account/package-lock.json
+++ b/clients/sub-account/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/sub-account",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/sub-account",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "1.0.2",

--- a/clients/sub-account/package.json
+++ b/clients/sub-account/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/sub-account",
     "description": "Official Binance Sub Account Connector - A lightweight library that provides a convenient interface to Binance's Sub Account REST API.",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/sub-account/src/rest-api/modules/api-management-api.ts
+++ b/clients/sub-account/src/rest-api/modules/api-management-api.ts
@@ -41,7 +41,7 @@ const ApiManagementApiAxiosParamCreator = function (configuration: Configuration
          * @param {string} email [Sub-account email](#email-address)
          * @param {string} subAccountApiKey
          * @param {string} status IP Restriction status. 1 = IP Unrestricted. 2 = Restrict access to trusted IPs only.
-         * @param {string} [ipAddress] Can be added in batches, separated by commas
+         * @param {string} [ipAddress] Insert static IP in batch, separated by commas.
          * @param {number} [recvWindow]
          *
          * @throws {RequiredError}
@@ -106,7 +106,7 @@ const ApiManagementApiAxiosParamCreator = function (configuration: Configuration
          * @summary Delete IP List For a Sub-account API Key (For Master Account) (USER_DATA)
          * @param {string} email [Sub-account email](#email-address)
          * @param {string} subAccountApiKey
-         * @param {string} [ipAddress] Can be added in batches, separated by commas
+         * @param {string} ipAddress IPs to be deleted. Can be added in batches, separated by commas
          * @param {number} [recvWindow]
          *
          * @throws {RequiredError}
@@ -114,7 +114,7 @@ const ApiManagementApiAxiosParamCreator = function (configuration: Configuration
         deleteIpListForASubAccountApiKey: async (
             email: string,
             subAccountApiKey: string,
-            ipAddress?: string,
+            ipAddress: string,
             recvWindow?: number
         ): Promise<RequestArgs> => {
             // verify required parameter 'email' is not null or undefined
@@ -125,6 +125,8 @@ const ApiManagementApiAxiosParamCreator = function (configuration: Configuration
                 'subAccountApiKey',
                 subAccountApiKey
             );
+            // verify required parameter 'ipAddress' is not null or undefined
+            assertParamExists('deleteIpListForASubAccountApiKey', 'ipAddress', ipAddress);
 
             const localVarQueryParameter: Record<string, unknown> = {};
 
@@ -287,7 +289,7 @@ export interface AddIpRestrictionForSubAccountApiKeyRequest {
     readonly status: string;
 
     /**
-     * Can be added in batches, separated by commas
+     * Insert static IP in batch, separated by commas.
      * @type {string}
      * @memberof ApiManagementApiAddIpRestrictionForSubAccountApiKey
      */
@@ -321,11 +323,11 @@ export interface DeleteIpListForASubAccountApiKeyRequest {
     readonly subAccountApiKey: string;
 
     /**
-     * Can be added in batches, separated by commas
+     * IPs to be deleted. Can be added in batches, separated by commas
      * @type {string}
      * @memberof ApiManagementApiDeleteIpListForASubAccountApiKey
      */
-    readonly ipAddress?: string;
+    readonly ipAddress: string;
 
     /**
      *

--- a/clients/sub-account/tests/unit/rest-api/ApiManagementApiTest.test.ts
+++ b/clients/sub-account/tests/unit/rest-api/ApiManagementApiTest.test.ts
@@ -172,6 +172,7 @@ describe('ApiManagementApi', () => {
             const params: DeleteIpListForASubAccountApiKeyRequest = {
                 email: 'sub-account-email@email.com',
                 subAccountApiKey: 'subAccountApiKey_example',
+                ipAddress: 'ipAddress_example',
             };
 
             mockResponse = {
@@ -228,6 +229,7 @@ describe('ApiManagementApi', () => {
             const _params: DeleteIpListForASubAccountApiKeyRequest = {
                 email: 'sub-account-email@email.com',
                 subAccountApiKey: 'subAccountApiKey_example',
+                ipAddress: 'ipAddress_example',
             };
             const params = Object.assign({ ..._params });
             delete params?.email;
@@ -241,6 +243,7 @@ describe('ApiManagementApi', () => {
             const _params: DeleteIpListForASubAccountApiKeyRequest = {
                 email: 'sub-account-email@email.com',
                 subAccountApiKey: 'subAccountApiKey_example',
+                ipAddress: 'ipAddress_example',
             };
             const params = Object.assign({ ..._params });
             delete params?.subAccountApiKey;
@@ -250,10 +253,25 @@ describe('ApiManagementApi', () => {
             );
         });
 
+        it('should throw RequiredError when ipAddress is missing', async () => {
+            const _params: DeleteIpListForASubAccountApiKeyRequest = {
+                email: 'sub-account-email@email.com',
+                subAccountApiKey: 'subAccountApiKey_example',
+                ipAddress: 'ipAddress_example',
+            };
+            const params = Object.assign({ ..._params });
+            delete params?.ipAddress;
+
+            await expect(client.deleteIpListForASubAccountApiKey(params)).rejects.toThrow(
+                'Required parameter ipAddress was null or undefined when calling deleteIpListForASubAccountApiKey.'
+            );
+        });
+
         it('should throw an error when server is returning an error', async () => {
             const params: DeleteIpListForASubAccountApiKeyRequest = {
                 email: 'sub-account-email@email.com',
                 subAccountApiKey: 'subAccountApiKey_example',
+                ipAddress: 'ipAddress_example',
             };
 
             const errorResponse = {


### PR DESCRIPTION
### Changed (1)

- Modified parameter `ipAddress` for the following methods:
  - `addIpRestrictionForSubAccountApiKey()` (`POST /sapi/v2/sub-account/subAccountApi/ipRestriction`)
  - `deleteIpListForASubAccountApiKey()` (`DELETE /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList`)