### PR TITLE
Release derivatives-trading-portfolio-margin-pro v6.0.0

### DIFF
--- a/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
+++ b/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.0.0 - 2025-05-28
+
+### Changed (1)
+
+- Marked as signed the following endpoints:
+  - `POST /sapi/v1/portfolio/repay`
+
 ## 5.0.0 - 2025-05-26
 
 ### Changed (1)

--- a/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-portfolio-margin-pro",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "1.0.2",

--- a/clients/derivatives-trading-portfolio-margin-pro/package.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
+++ b/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
@@ -1745,7 +1745,7 @@ export class AccountApi implements AccountApiInterface {
             localVarAxiosArgs.method,
             localVarAxiosArgs.params,
             localVarAxiosArgs?.timeUnit,
-            { isSigned: false }
+            { isSigned: true }
         );
     }
 


### PR DESCRIPTION
### Changed (1)

- Marked as signed the following endpoints:
  - `POST /sapi/v1/portfolio/repay`