### PR TITLE
Release common v1.0.5

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.5 - 2025-05-28
+
+### Changed
+
+- Updated `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_PROD_URL` to `https://api.binance.com`.
+- Removed `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_TESTNET_URL`.
+
 ## 1.0.4 - 2025-05-13
 
 ### Added

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/common",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/common",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/common/package.json
+++ b/common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/common",
     "description": "Binance Common Types and Utilities for Binance Connectors",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -60,9 +60,7 @@ export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_TESTNET_URL =
 
 // Derivatives Trading (Portfolio Margin Pro) constants
 export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_PROD_URL =
-    'https://fapi.binance.com';
-export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_TESTNET_URL =
-    'https://testnet.binancefuture.com';
+    'https://api.binance.com';
 
 // Dual Investment constants
 export const DUAL_INVESTMENT_REST_API_PROD_URL = 'https://api.binance.com';


### PR DESCRIPTION
### Changed

- Updated `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_PROD_URL` to `https://api.binance.com`.
- Removed `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_TESTNET_URL`.