### PR TITLE
Release derivatives-trading-portfolio-margin-pro v6.0.0

### DIFF
--- a/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
+++ b/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.0.0 - 2025-05-28
+
+### Changed (1)
+
+- Marked as signed the following endpoints:
+  - `POST /sapi/v1/portfolio/repay`
+- Updated `@binance/common` library to version `1.0.5`.
+
 ## 5.0.0 - 2025-05-26
 
 ### Changed (1)

--- a/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-portfolio-margin-pro",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.2",
+                "@binance/common": "1.0.5",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
             },
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.2.tgz",
-            "integrity": "sha512-xRh7b5PXWJcVLOwV8bz+GsGXHmayFhI63WNoDhgOOX/4VaIZu0yiTO2l92BxfxgCyP8HDnK/GsnheOoGSIc/Dw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.5.tgz",
+            "integrity": "sha512-qd0ygNZ61app/Mrd6czfp3NG89+wPsEfU4UaFSBIG8dzJ7p/mc6N0f3oDmFgvrNNCeqI84MlhIBcA8n3h8CA1A==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/derivatives-trading-portfolio-margin-pro/package.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -51,7 +51,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.0.2",
+        "@binance/common": "1.0.5",
         "axios": "^1.7.4",
         "ws": "^8.17.1"
     }

--- a/clients/derivatives-trading-portfolio-margin-pro/src/index.ts
+++ b/clients/derivatives-trading-portfolio-margin-pro/src/index.ts
@@ -6,7 +6,6 @@ export * as DerivativesTradingPortfolioMarginProRestAPI from './rest-api';
 
 export {
     DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_PROD_URL,
-    DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_TESTNET_URL,
     ConnectorClientError,
     RequiredError,
     UnauthorizedError,

--- a/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
+++ b/clients/derivatives-trading-portfolio-margin-pro/src/rest-api/modules/account-api.ts
@@ -1745,7 +1745,7 @@ export class AccountApi implements AccountApiInterface {
             localVarAxiosArgs.method,
             localVarAxiosArgs.params,
             localVarAxiosArgs?.timeUnit,
-            { isSigned: false }
+            { isSigned: true }
         );
     }
 


### PR DESCRIPTION
### Changed (1)

- Marked as signed the following endpoints:
  - `POST /sapi/v1/portfolio/repay`
- Updated `@binance/common` library to version `1.0.5`.