### PR TITLE
Release simple-earn v5.0.0

### DIFF
--- a/clients/simple-earn/CHANGELOG.md
+++ b/clients/simple-earn/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.0.0 - 2025-06-03
+
+### Changed (1)
+
+- Added parameter `recvWindow`
+  - affected methods:
+    - `getFlexibleRedemptionRecord()` (`GET /sapi/v1/simple-earn/flexible/history/redemptionRecord`)
+
 ## 4.0.0 - 2025-05-28
 
 ### Changed (1)

--- a/clients/simple-earn/package-lock.json
+++ b/clients/simple-earn/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/simple-earn",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/simple-earn",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "1.0.2",

--- a/clients/simple-earn/package.json
+++ b/clients/simple-earn/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/simple-earn",
     "description": "Official Binance Simple Earn Connector - A lightweight library that provides a convenient interface to Binance's Simple Earn REST API.",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/simple-earn/src/rest-api/modules/history-api.ts
+++ b/clients/simple-earn/src/rest-api/modules/history-api.ts
@@ -117,6 +117,7 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
          * @param {number} [endTime]
          * @param {number} [current] Currently querying the page. Start from 1. Default:1
          * @param {number} [size] Default:10, Max:100
+         * @param {number} [recvWindow]
          *
          * @throws {RequiredError}
          */
@@ -127,7 +128,8 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
             startTime?: number,
             endTime?: number,
             current?: number,
-            size?: number
+            size?: number,
+            recvWindow?: number
         ): Promise<RequestArgs> => {
             const localVarQueryParameter: Record<string, unknown> = {};
 
@@ -157,6 +159,10 @@ const HistoryApiAxiosParamCreator = function (configuration: ConfigurationRestAP
 
             if (size !== undefined && size !== null) {
                 localVarQueryParameter['size'] = size;
+            }
+
+            if (recvWindow !== undefined && recvWindow !== null) {
+                localVarQueryParameter['recvWindow'] = recvWindow;
             }
 
             let _timeUnit: TimeUnit | undefined;
@@ -876,6 +882,13 @@ export interface GetFlexibleRedemptionRecordRequest {
      * @memberof HistoryApiGetFlexibleRedemptionRecord
      */
     readonly size?: number;
+
+    /**
+     *
+     * @type {number}
+     * @memberof HistoryApiGetFlexibleRedemptionRecord
+     */
+    readonly recvWindow?: number;
 }
 
 /**
@@ -1307,7 +1320,8 @@ export class HistoryApi implements HistoryApiInterface {
             requestParameters?.startTime,
             requestParameters?.endTime,
             requestParameters?.current,
-            requestParameters?.size
+            requestParameters?.size,
+            requestParameters?.recvWindow
         );
         return sendRequest<GetFlexibleRedemptionRecordResponse>(
             this.configuration,

--- a/clients/simple-earn/tests/unit/rest-api/HistoryApiTest.test.ts
+++ b/clients/simple-earn/tests/unit/rest-api/HistoryApiTest.test.ts
@@ -176,6 +176,7 @@ describe('HistoryApi', () => {
                 endTime: 1641782889000,
                 current: 1,
                 size: 10,
+                recvWindow: 5000,
             };
 
             mockResponse = {


### PR DESCRIPTION
### Changed (1)

- Added parameter `recvWindow`
  - affected methods:
    - `getFlexibleRedemptionRecord()` (`GET /sapi/v1/simple-earn/flexible/history/redemptionRecord`)