### PR TITLE
Release common v1.0.6

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.6 - 2025-06-03
+
+### Changed
+
+- Fixed bug on `ConfigurationRestAPI` not respecting `baseOptions` parameters.
+
 ## 1.0.5 - 2025-05-28
 
 ### Changed

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/common",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/common",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/common/package.json
+++ b/common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/common",
     "description": "Binance Common Types and Utilities for Binance Connectors",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/common/src/configuration.ts
+++ b/common/src/configuration.ts
@@ -115,16 +115,16 @@ export class ConfigurationRestAPI {
         this.privateKeyPassphrase = param.privateKeyPassphrase;
         this.timeUnit = param.timeUnit;
         this.baseOptions = {
-            timeout: this.timeout ?? 1000,
-            proxy: this.proxy && {
-                host: this.proxy.host,
-                port: this.proxy.port,
-                auth: this.proxy.auth,
+            timeout: param.timeout ?? 1000,
+            proxy: param.proxy && {
+                host: param.proxy.host,
+                port: param.proxy.port,
+                auth: param.proxy.auth,
             },
-            httpsAgent: this.httpsAgent ?? false,
+            httpsAgent: param.httpsAgent ?? false,
             headers: {
                 'Content-Type': 'application/json',
-                'X-MBX-APIKEY': this.apiKey,
+                'X-MBX-APIKEY': param.apiKey,
             },
         };
     }


### PR DESCRIPTION
### Changed

- Fixed bug on `ConfigurationRestAPI` not respecting `baseOptions` parameters.