### PR TITLE
Release c2c v2.0.1

### DIFF
--- a/clients/c2c/CHANGELOG.md
+++ b/clients/c2c/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1 - 2025-06-03
+
+### Changed
+
+- Update `@binance/common` library to version `1.0.6`.
+
 ## 2.0.0 - 2025-04-10
 
 ### Changed

--- a/clients/c2c/package-lock.json
+++ b/clients/c2c/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/c2c",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/c2c",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.2",
+                "@binance/common": "^1.0.6",
                 "axios": "^1.7.4"
             },
             "devDependencies": {
@@ -536,9 +536,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.2.tgz",
-            "integrity": "sha512-xRh7b5PXWJcVLOwV8bz+GsGXHmayFhI63WNoDhgOOX/4VaIZu0yiTO2l92BxfxgCyP8HDnK/GsnheOoGSIc/Dw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
+            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/c2c/package.json
+++ b/clients/c2c/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/c2c",
     "description": "Official Binance C2C Connector - A lightweight library that provides a convenient interface to Binance's C2C REST API.",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -55,7 +55,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.0.2",
+        "@binance/common": "^1.0.6",
         "axios": "^1.7.4"
     }
 }


### PR DESCRIPTION
### Changed

- Update `@binance/common` library to version `1.0.6`.