### PR TITLE
Release derivatives-trading-portfolio-margin v3.0.1

### DIFF
--- a/clients/derivatives-trading-portfolio-margin/CHANGELOG.md
+++ b/clients/derivatives-trading-portfolio-margin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1 - 2025-06-03
+
+### Changed
+
+- Update `@binance/common` library to version `1.0.6`.
+
 ## 3.0.0 - 2025-05-14
 
 ### Changed

--- a/clients/derivatives-trading-portfolio-margin/package-lock.json
+++ b/clients/derivatives-trading-portfolio-margin/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-portfolio-margin",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.2",
+                "@binance/common": "^1.0.6",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
             },
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.2.tgz",
-            "integrity": "sha512-xRh7b5PXWJcVLOwV8bz+GsGXHmayFhI63WNoDhgOOX/4VaIZu0yiTO2l92BxfxgCyP8HDnK/GsnheOoGSIc/Dw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
+            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/derivatives-trading-portfolio-margin/package.json
+++ b/clients/derivatives-trading-portfolio-margin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -51,7 +51,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.0.2",
+        "@binance/common": "^1.0.6",
         "axios": "^1.7.4",
         "ws": "^8.17.1"
     }


### PR DESCRIPTION
### Changed

- Update `@binance/common` library to version `1.0.6`.