### PR TITLE
Release derivatives-trading-portfolio-margin-pro v6.0.1

### DIFF
--- a/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
+++ b/clients/derivatives-trading-portfolio-margin-pro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.1 - 2025-06-03
+
+### Changed
+
+- Update `@binance/common` library to version `1.0.6`.
+
 ## 6.0.0 - 2025-05-28
 
 ### Changed (1)

--- a/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-portfolio-margin-pro",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.0.5",
+                "@binance/common": "^1.0.6",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
             },
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.5.tgz",
-            "integrity": "sha512-qd0ygNZ61app/Mrd6czfp3NG89+wPsEfU4UaFSBIG8dzJ7p/mc6N0f3oDmFgvrNNCeqI84MlhIBcA8n3h8CA1A==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
+            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/derivatives-trading-portfolio-margin-pro/package.json
+++ b/clients/derivatives-trading-portfolio-margin-pro/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-portfolio-margin-pro",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -51,7 +51,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.0.5",
+        "@binance/common": "^1.0.6",
         "axios": "^1.7.4",
         "ws": "^8.17.1"
     }


### PR DESCRIPTION
### Changed

- Update `@binance/common` library to version `1.0.6`.