### PR TITLE
Release copy-trading v2.0.2

### DIFF
--- a/clients/copy-trading/CHANGELOG.md
+++ b/clients/copy-trading/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2 - 2025-06-05
+
+### Changed (1)
+
+- Update `@binance/common` library to version `1.1.0`.
+
 ## 2.0.1 - 2025-06-03
 
 ### Changed

--- a/clients/copy-trading/package-lock.json
+++ b/clients/copy-trading/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/copy-trading",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/copy-trading",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "^1.0.6",
+                "@binance/common": "^1.1.0",
                 "axios": "^1.7.4"
             },
             "devDependencies": {
@@ -536,9 +536,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
-            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.0.tgz",
+            "integrity": "sha512-+kAPMKtE50GfxE7kAwjT4YHaCFwP/Bkzwo1ujlhvK8jDu9j7TFeZvW10/xhCXyQ+7juSwSL8xqpn7QtpuZfmbQ==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/copy-trading/package.json
+++ b/clients/copy-trading/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/copy-trading",
     "description": "Official Binance Copy Trading Connector - A lightweight library that provides a convenient interface to Binance's Copy Trading REST API.",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsup",
+        "build": "npm run clean && tsup",
         "typecheck": "tsc --noEmit",
         "clean": "rm -rf dist",
         "test": "npx jest --maxWorkers=4 --bail",
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "^1.0.6",
+        "@binance/common": "^1.1.0",
         "axios": "^1.7.4"
     }
 }


### PR DESCRIPTION
### Changed (1)

- Update `@binance/common` library to version `1.1.0`.