### PR TITLE
Release margin-trading v4.0.0

### DIFF
--- a/clients/margin-trading/CHANGELOG.md
+++ b/clients/margin-trading/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.0 - 2025-06-xx
+
+### Changed (2)
+
+- Fix bug with enums exporting.
+- Update `@binance/common` library to version `1.1.0`.
+
 ## 3.0.1 - 2025-06-03
 
 ### Changed

--- a/clients/margin-trading/package-lock.json
+++ b/clients/margin-trading/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/margin-trading",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/margin-trading",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "^1.0.6",
+                "@binance/common": "^1.1.0",
                 "axios": "^1.7.4"
             },
             "devDependencies": {
@@ -536,9 +536,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
-            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.0.tgz",
+            "integrity": "sha512-+kAPMKtE50GfxE7kAwjT4YHaCFwP/Bkzwo1ujlhvK8jDu9j7TFeZvW10/xhCXyQ+7juSwSL8xqpn7QtpuZfmbQ==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/margin-trading/package.json
+++ b/clients/margin-trading/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/margin-trading",
     "description": "Official Binance Margin Trading Connector - A lightweight library that provides a convenient interface to Binance's Margin Trading REST API.",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsup",
+        "build": "npm run clean && tsup",
         "typecheck": "tsc --noEmit",
         "clean": "rm -rf dist",
         "test": "npx jest --maxWorkers=4 --bail",
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "^1.0.6",
+        "@binance/common": "^1.1.0",
         "axios": "^1.7.4"
     }
 }

--- a/clients/margin-trading/src/rest-api/modules/trade-api.ts
+++ b/clients/margin-trading/src/rest-api/modules/trade-api.ts
@@ -4593,56 +4593,42 @@ export class TradeApi implements TradeApiInterface {
     }
 }
 
-export const MarginAccountNewOcoSideEnum = {
-    BUY: 'BUY',
-    SELL: 'SELL',
-} as const;
-export type MarginAccountNewOcoSideEnum =
-    (typeof MarginAccountNewOcoSideEnum)[keyof typeof MarginAccountNewOcoSideEnum];
+export enum MarginAccountNewOcoSideEnum {
+    BUY = 'BUY',
+    SELL = 'SELL',
+}
 
-export const MarginAccountNewOcoNewOrderRespTypeEnum = {
-    ACK: 'ACK',
-    RESULT: 'RESULT',
-    FULL: 'FULL',
-} as const;
-export type MarginAccountNewOcoNewOrderRespTypeEnum =
-    (typeof MarginAccountNewOcoNewOrderRespTypeEnum)[keyof typeof MarginAccountNewOcoNewOrderRespTypeEnum];
+export enum MarginAccountNewOcoNewOrderRespTypeEnum {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+    FULL = 'FULL',
+}
 
-export const MarginAccountNewOrderSideEnum = {
-    BUY: 'BUY',
-    SELL: 'SELL',
-} as const;
-export type MarginAccountNewOrderSideEnum =
-    (typeof MarginAccountNewOrderSideEnum)[keyof typeof MarginAccountNewOrderSideEnum];
+export enum MarginAccountNewOrderSideEnum {
+    BUY = 'BUY',
+    SELL = 'SELL',
+}
 
-export const MarginAccountNewOrderNewOrderRespTypeEnum = {
-    ACK: 'ACK',
-    RESULT: 'RESULT',
-    FULL: 'FULL',
-} as const;
-export type MarginAccountNewOrderNewOrderRespTypeEnum =
-    (typeof MarginAccountNewOrderNewOrderRespTypeEnum)[keyof typeof MarginAccountNewOrderNewOrderRespTypeEnum];
+export enum MarginAccountNewOrderNewOrderRespTypeEnum {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+    FULL = 'FULL',
+}
 
-export const MarginAccountNewOrderTimeInForceEnum = {
-    GTC: 'GTC',
-    IOC: 'IOC',
-    FOK: 'FOK',
-} as const;
-export type MarginAccountNewOrderTimeInForceEnum =
-    (typeof MarginAccountNewOrderTimeInForceEnum)[keyof typeof MarginAccountNewOrderTimeInForceEnum];
+export enum MarginAccountNewOrderTimeInForceEnum {
+    GTC = 'GTC',
+    IOC = 'IOC',
+    FOK = 'FOK',
+}
 
-export const MarginAccountNewOtoNewOrderRespTypeEnum = {
-    ACK: 'ACK',
-    RESULT: 'RESULT',
-    FULL: 'FULL',
-} as const;
-export type MarginAccountNewOtoNewOrderRespTypeEnum =
-    (typeof MarginAccountNewOtoNewOrderRespTypeEnum)[keyof typeof MarginAccountNewOtoNewOrderRespTypeEnum];
+export enum MarginAccountNewOtoNewOrderRespTypeEnum {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+    FULL = 'FULL',
+}
 
-export const MarginAccountNewOtocoNewOrderRespTypeEnum = {
-    ACK: 'ACK',
-    RESULT: 'RESULT',
-    FULL: 'FULL',
-} as const;
-export type MarginAccountNewOtocoNewOrderRespTypeEnum =
-    (typeof MarginAccountNewOtocoNewOrderRespTypeEnum)[keyof typeof MarginAccountNewOtocoNewOrderRespTypeEnum];
+export enum MarginAccountNewOtocoNewOrderRespTypeEnum {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+    FULL = 'FULL',
+}


### PR DESCRIPTION
### Changed (2)

- Fix bug with enums exporting.
- Update `@binance/common` library to version `1.1.0`.