### PR TITLE
Release derivatives-trading-options v4.0.0

### DIFF
--- a/clients/derivatives-trading-options/CHANGELOG.md
+++ b/clients/derivatives-trading-options/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.0 - 2025-06-05
+
+### Changed (2)
+
+- Fix bug with enums exporting.
+- Update `@binance/common` library to version `1.1.0`.
+
 ## 3.0.1 - 2025-06-03
 
 ### Changed

--- a/clients/derivatives-trading-options/package-lock.json
+++ b/clients/derivatives-trading-options/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-options",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-options",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "^1.0.6",
+                "@binance/common": "^1.1.0",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
             },
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.0.6.tgz",
-            "integrity": "sha512-qMZaQFi+TsktjvdvPejOVRKxSTP9UiZ66oDJ8zfpC9gs0Vaaa4vD+AHKC1OgB0IsiHPstXJ+ZxivuOwoyLyjPw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.0.tgz",
+            "integrity": "sha512-+kAPMKtE50GfxE7kAwjT4YHaCFwP/Bkzwo1ujlhvK8jDu9j7TFeZvW10/xhCXyQ+7juSwSL8xqpn7QtpuZfmbQ==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/clients/derivatives-trading-options/package.json
+++ b/clients/derivatives-trading-options/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-options",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsup",
+        "build": "npm run clean && tsup",
         "typecheck": "tsc --noEmit",
         "clean": "rm -rf dist",
         "test": "npx jest --maxWorkers=4 --bail",
@@ -51,7 +51,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "^1.0.6",
+        "@binance/common": "^1.1.0",
         "axios": "^1.7.4",
         "ws": "^8.17.1"
     }

--- a/clients/derivatives-trading-options/src/rest-api/modules/market-maker-block-trade-api.ts
+++ b/clients/derivatives-trading-options/src/rest-api/modules/market-maker-block-trade-api.ts
@@ -924,9 +924,7 @@ export class MarketMakerBlockTradeApi implements MarketMakerBlockTradeApiInterfa
     }
 }
 
-export const NewBlockTradeOrderSideEnum = {
-    BUY: 'BUY',
-    SELL: 'SELL',
-} as const;
-export type NewBlockTradeOrderSideEnum =
-    (typeof NewBlockTradeOrderSideEnum)[keyof typeof NewBlockTradeOrderSideEnum];
+export enum NewBlockTradeOrderSideEnum {
+    BUY = 'BUY',
+    SELL = 'SELL',
+}

--- a/clients/derivatives-trading-options/src/rest-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-options/src/rest-api/modules/trade-api.ts
@@ -1749,28 +1749,22 @@ export class TradeApi implements TradeApiInterface {
     }
 }
 
-export const NewOrderSideEnum = {
-    BUY: 'BUY',
-    SELL: 'SELL',
-} as const;
-export type NewOrderSideEnum = (typeof NewOrderSideEnum)[keyof typeof NewOrderSideEnum];
+export enum NewOrderSideEnum {
+    BUY = 'BUY',
+    SELL = 'SELL',
+}
 
-export const NewOrderTypeEnum = {
-    LIMIT: 'LIMIT',
-} as const;
-export type NewOrderTypeEnum = (typeof NewOrderTypeEnum)[keyof typeof NewOrderTypeEnum];
+export enum NewOrderTypeEnum {
+    LIMIT = 'LIMIT',
+}
 
-export const NewOrderTimeInForceEnum = {
-    GTC: 'GTC',
-    IOC: 'IOC',
-    FOK: 'FOK',
-} as const;
-export type NewOrderTimeInForceEnum =
-    (typeof NewOrderTimeInForceEnum)[keyof typeof NewOrderTimeInForceEnum];
+export enum NewOrderTimeInForceEnum {
+    GTC = 'GTC',
+    IOC = 'IOC',
+    FOK = 'FOK',
+}
 
-export const NewOrderNewOrderRespTypeEnum = {
-    ACK: 'ACK',
-    RESULT: 'RESULT',
-} as const;
-export type NewOrderNewOrderRespTypeEnum =
-    (typeof NewOrderNewOrderRespTypeEnum)[keyof typeof NewOrderNewOrderRespTypeEnum];
+export enum NewOrderNewOrderRespTypeEnum {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+}

--- a/clients/derivatives-trading-options/tests/unit/websocket-streams/WebsocketMarketStreamsApiTest.test.ts
+++ b/clients/derivatives-trading-options/tests/unit/websocket-streams/WebsocketMarketStreamsApiTest.test.ts
@@ -60,7 +60,7 @@ describe('WebsocketMarketStreamsApi', () => {
             const mockResponse = { e: 'index', E: 1661415480351, s: 'ETHUSDT', p: '1707.89008607' };
 
             const stream = websocketStreamApi.indexPriceStreams(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -168,7 +168,7 @@ describe('WebsocketMarketStreamsApi', () => {
             };
 
             const stream = websocketStreamApi.klineCandlestickStreams(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -254,7 +254,7 @@ describe('WebsocketMarketStreamsApi', () => {
             ];
 
             const stream = websocketStreamApi.markPrice(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -336,7 +336,7 @@ describe('WebsocketMarketStreamsApi', () => {
             };
 
             const stream = websocketStreamApi.newSymbolInfo(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -400,7 +400,7 @@ describe('WebsocketMarketStreamsApi', () => {
             ];
 
             const stream = websocketStreamApi.openInterest(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -510,7 +510,7 @@ describe('WebsocketMarketStreamsApi', () => {
             };
 
             const stream = websocketStreamApi.partialBookDepthStreams(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -654,7 +654,7 @@ describe('WebsocketMarketStreamsApi', () => {
             };
 
             const stream = websocketStreamApi.ticker24Hour(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -851,7 +851,7 @@ describe('WebsocketMarketStreamsApi', () => {
 
             const stream =
                 websocketStreamApi.ticker24HourByUnderlyingAssetAndExpirationData(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](
@@ -962,7 +962,7 @@ describe('WebsocketMarketStreamsApi', () => {
             };
 
             const stream = websocketStreamApi.tradeStreams(params);
-            const mockCallback = jest.fn();
+            const mockCallback = jest.fn(() => {});
             stream.on('message', mockCallback);
 
             websocketStreamClient['onMessage'](


### PR DESCRIPTION
### Changed (2)

- Fix bug with enums exporting.
- Update `@binance/common` library to version `1.1.0`.