### PR TITLE
Release margin-trading v5.0.1

### DIFF
--- a/clients/margin-trading/CHANGELOG.md
+++ b/clients/margin-trading/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.1 - 2025-06-19
+
+### Changed (1)
+
+- Update `@binance/common` library to version `1.1.2`.
+
 ## 5.0.0 - 2025-06-16
 
 ### Added (1)

--- a/clients/margin-trading/package-lock.json
+++ b/clients/margin-trading/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/margin-trading",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/margin-trading",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "^1.1.1",
+                "@binance/common": "^1.1.2",
                 "axios": "^1.7.4"
             },
             "devDependencies": {
@@ -536,9 +536,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.1.tgz",
-            "integrity": "sha512-qBROPYc5sp8eRtcxCwfViXBmcqhtY+s5b2Amd163b68nD5HUSFA50w6Ie/EaC4cmUKctEVfmAZcPYjYAhxhK7A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.2.tgz",
+            "integrity": "sha512-QCdOI8Bp6Q6Sm5A7lgMpGqGK6lFHpBUQrZxYOqn6mlmBI9R2O7d6+okwsqk6+TUMUUvNzS7+D/l85/k93i7gyw==",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.5.5",

--- a/clients/margin-trading/package.json
+++ b/clients/margin-trading/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/margin-trading",
     "description": "Official Binance Margin Trading Connector - A lightweight library that provides a convenient interface to Binance's Margin Trading REST API.",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "^1.1.1",
+        "@binance/common": "^1.1.2",
         "axios": "^1.7.4"
     }
 }

--- a/clients/margin-trading/src/margin-trading.ts
+++ b/clients/margin-trading/src/margin-trading.ts
@@ -1,5 +1,8 @@
-import { platform, arch } from 'os';
-import { ConfigurationRestAPI, MARGIN_TRADING_REST_API_PROD_URL } from '@binance/common';
+import {
+    buildUserAgent,
+    ConfigurationRestAPI,
+    MARGIN_TRADING_REST_API_PROD_URL,
+} from '@binance/common';
 import { name, version } from '../package.json';
 import { RestAPI } from './rest-api';
 
@@ -11,13 +14,19 @@ export class MarginTrading {
     public restAPI!: RestAPI;
 
     constructor(config: ConfigurationMarginTrading) {
+        const userAgent = buildUserAgent(name, version);
+
         if (config?.configurationRestAPI) {
-            const configRestAPI = new ConfigurationRestAPI(config.configurationRestAPI);
+            const configRestAPI = new ConfigurationRestAPI(
+                config.configurationRestAPI
+            ) as ConfigurationRestAPI & {
+                baseOptions: Record<string, unknown>;
+            };
             configRestAPI.basePath = configRestAPI.basePath || MARGIN_TRADING_REST_API_PROD_URL;
             configRestAPI.baseOptions = configRestAPI.baseOptions || {};
             configRestAPI.baseOptions.headers = {
                 ...(configRestAPI.baseOptions.headers || {}),
-                'User-Agent': `${name}/${version} (Node.js/${process.version}; ${platform()}; ${arch()})`,
+                'User-Agent': userAgent,
             };
             this.restAPI = new RestAPI(configRestAPI);
         }


### PR DESCRIPTION
### Changed (1)

- Update `@binance/common` library to version `1.1.2`.