### PR TITLE
Release derivatives-trading-usds-futures v8.0.0

### DIFF
--- a/clients/derivatives-trading-usds-futures/CHANGELOG.md
+++ b/clients/derivatives-trading-usds-futures/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.0.0 - 2025-06-24
+
+### Changed (1)
+
+#### REST API
+
+- Modified response for `exchangeInformation()` method (`GET /fapi/v1/exchangeInfo`):
+  - `assets`.`autoAssetExchange`: type `integer` → `string`
+  - `symbols`.`filters`.`multiplierDecimal`: type `integer` → `string`
+
 ## 7.0.2 - 2025-06-19
 
 ### Changed (1)

--- a/clients/derivatives-trading-usds-futures/package-lock.json
+++ b/clients/derivatives-trading-usds-futures/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/derivatives-trading-usds-futures",
-    "version": "7.0.2",
+    "version": "8.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-usds-futures",
-            "version": "7.0.2",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
                 "@binance/common": "^1.1.2",

--- a/clients/derivatives-trading-usds-futures/package.json
+++ b/clients/derivatives-trading-usds-futures/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-usds-futures",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "7.0.2",
+    "version": "8.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-assets-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-assets-inner.ts
@@ -33,8 +33,8 @@ export interface ExchangeInformationResponseAssetsInner {
     marginAvailable?: boolean;
     /**
      *
-     * @type {number}
+     * @type {string}
      * @memberof ExchangeInformationResponseAssetsInner
      */
-    autoAssetExchange?: number;
+    autoAssetExchange?: string;
 }

--- a/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner-filters-inner.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/types/exchange-information-response-symbols-inner-filters-inner.ts
@@ -87,8 +87,8 @@ export interface ExchangeInformationResponseSymbolsInnerFiltersInner {
     multiplierDown?: string;
     /**
      *
-     * @type {number}
+     * @type {string}
      * @memberof ExchangeInformationResponseSymbolsInnerFiltersInner
      */
-    multiplierDecimal?: number;
+    multiplierDecimal?: string;
 }

--- a/clients/derivatives-trading-usds-futures/tests/unit/rest-api/MarketDataApiTest.test.ts
+++ b/clients/derivatives-trading-usds-futures/tests/unit/rest-api/MarketDataApiTest.test.ts
@@ -663,8 +663,8 @@ describe('MarketDataApi', () => {
                 ],
                 serverTime: 1565613908500,
                 assets: [
-                    { asset: 'BUSD', marginAvailable: true, autoAssetExchange: 0 },
-                    { asset: 'USDT', marginAvailable: true, autoAssetExchange: 0 },
+                    { asset: 'BTC', marginAvailable: true, autoAssetExchange: '-0.10' },
+                    { asset: 'USDT', marginAvailable: true, autoAssetExchange: '0' },
                     { asset: 'BNB', marginAvailable: false, autoAssetExchange: null },
                 ],
                 symbols: [
@@ -714,7 +714,7 @@ describe('MarketDataApi', () => {
                                 filterType: 'PERCENT_PRICE',
                                 multiplierUp: '1.1500',
                                 multiplierDown: '0.8500',
-                                multiplierDecimal: 4,
+                                multiplierDecimal: '4',
                             },
                         ],
                         OrderType: [


### PR DESCRIPTION
### Changed (1)

#### REST API

- Modified response for `exchangeInformation()` method (`GET /fapi/v1/exchangeInfo`):
  - `assets`.`autoAssetExchange`: type `integer` → `string`
  - `symbols`.`filters`.`multiplierDecimal`: type `integer` → `string`