### PR TITLE
Release copy-trading v2.0.5

### DIFF
--- a/clients/copy-trading/CHANGELOG.md
+++ b/clients/copy-trading/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.5 - 2025-07-08
+
+### Changed (1)
+
+- Update `@binance/common` library to version `1.2.0`.
+
 ## 2.0.4 - 2025-06-19
 
 ### Changed (1)

--- a/clients/copy-trading/package-lock.json
+++ b/clients/copy-trading/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/copy-trading",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/copy-trading",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "^1.1.2",
+                "@binance/common": "1.2.0",
                 "axios": "^1.7.4"
             },
             "devDependencies": {
@@ -536,9 +536,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.2.tgz",
-            "integrity": "sha512-QCdOI8Bp6Q6Sm5A7lgMpGqGK6lFHpBUQrZxYOqn6mlmBI9R2O7d6+okwsqk6+TUMUUvNzS7+D/l85/k93i7gyw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.2.0.tgz",
+            "integrity": "sha512-l8IuMOlYA3hBtxtctnCS7JG0EyuT5SicM3Y1gP/r090rgOmN4DA/F+sP2Q45p6UmtVADqIXhop3iOHhuru3ggg==",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.5.5",

--- a/clients/copy-trading/package.json
+++ b/clients/copy-trading/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/copy-trading",
     "description": "Official Binance Copy Trading Connector - A lightweight library that provides a convenient interface to Binance's Copy Trading REST API.",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "^1.1.2",
+        "@binance/common": "1.2.0",
         "axios": "^1.7.4"
     }
 }


### PR DESCRIPTION
### Changed (1)

- Update `@binance/common` library to version `1.2.0`.