### PR TITLE
Release derivatives-trading-options v5.0.1

### DIFF
--- a/clients/derivatives-trading-options/CHANGELOG.md
+++ b/clients/derivatives-trading-options/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.1 - 2025-07-08
+
+### Changed (1)
+
+- Update `@binance/common` library to version `1.2.0`.
+
 ## 5.0.0 - 2025-06-30
 
 ### Added (1)

--- a/clients/derivatives-trading-options/package-lock.json
+++ b/clients/derivatives-trading-options/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-options",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-options",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.1.3",
+                "@binance/common": "1.2.0",
                 "@types/ws": "^8.5.5",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.1.3.tgz",
-            "integrity": "sha512-+LmGfF9PnoIcfEe8yhvLsVcmyn8AvZXqh9nnMqDUyOQoGTzEtzLRbWgPTmHswq7NSIDldM7OHgrxeOIZ0qVr1g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.2.0.tgz",
+            "integrity": "sha512-l8IuMOlYA3hBtxtctnCS7JG0EyuT5SicM3Y1gP/r090rgOmN4DA/F+sP2Q45p6UmtVADqIXhop3iOHhuru3ggg==",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.5.5",

--- a/clients/derivatives-trading-options/package.json
+++ b/clients/derivatives-trading-options/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-options",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -50,7 +50,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.1.3",
+        "@binance/common": "1.2.0",
         "@types/ws": "^8.5.5",
         "axios": "^1.7.4",
         "ws": "^8.17.1"


### PR DESCRIPTION
### Changed (1)

- Update `@binance/common` library to version `1.2.0`.