### PR TITLE
Release derivatives-trading-coin-futures v6.0.3

### DIFF
--- a/clients/derivatives-trading-coin-futures/CHANGELOG.md
+++ b/clients/derivatives-trading-coin-futures/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.3 - 2025-07-29
+
+### Changed (1)
+
+- Update `@binance/common` library to version `1.2.3`.
+
 ## 6.0.2 - 2025-07-22
 
 ### Changed (2)

--- a/clients/derivatives-trading-coin-futures/package-lock.json
+++ b/clients/derivatives-trading-coin-futures/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@binance/derivatives-trading-coin-futures",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/derivatives-trading-coin-futures",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "license": "MIT",
             "dependencies": {
-                "@binance/common": "1.2.2",
+                "@binance/common": "1.2.3",
                 "@types/ws": "^8.5.5",
                 "axios": "^1.7.4",
                 "ws": "^8.17.1"
@@ -538,9 +538,9 @@
             "license": "MIT"
         },
         "node_modules/@binance/common": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.2.2.tgz",
-            "integrity": "sha512-HZiWXd7pU8Z3Zyc35lsunT+eXFm9Os/xDnE2dEw+tpnuamkZbZrPm2dDQdur0BRABr8jzzsC02FZqnkmhOiizA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@binance/common/-/common-1.2.3.tgz",
+            "integrity": "sha512-GMmREqIruRbKmItw6b2us/7xWpE+uV1TglkdmPNFjrvw3gQBlWVgfqTMnPuB4qP0dza+bjrVXCtzbBMViPgzSw==",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.5.5",

--- a/clients/derivatives-trading-coin-futures/package.json
+++ b/clients/derivatives-trading-coin-futures/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@binance/derivatives-trading-coin-futures",
     "description": "Official Binance Derivatives Trading (COIN-M Futures) Connector - A lightweight library that provides a convenient interface to Binance's COINN-M Futures REST API, WebSocket API and WebSocket Streams.",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -50,7 +50,7 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
-        "@binance/common": "1.2.2",
+        "@binance/common": "1.2.3",
         "@types/ws": "^8.5.5",
         "axios": "^1.7.4",
         "ws": "^8.17.1"


### PR DESCRIPTION
### Changed (1)

- Update `@binance/common` library to version `1.2.3`.