### PR TITLE
fix the fiatWithdraw invalid signature error

### DIFF
--- a/common/src/utils.ts
+++ b/common/src/utils.ts
@@ -112,7 +112,7 @@ class RequestSigner {
     sign(queryParams: Record<string, unknown>, bodyParams?: Record<string, unknown>): string {
         const queryParamsString = buildQueryString(queryParams);
         const bodyParamsString = bodyParams ? buildQueryString(bodyParams) : '';
-        const params = queryParamsString + bodyParamsString;
+        const params = queryParamsString + (bodyParamsString && queryParamsString ? '&' : '') + bodyParamsString;
 
         // HMAC-SHA256 signing
         if (this.apiSecret)


### PR DESCRIPTION
## Fix: Invalid signature for requests with body parameters

### Problem
Authenticated `POST` / `PUT` / `DELETE` requests with body parameters were failing with:
`BadRequestError: Signature for this request is not valid`.

This affected endpoints such as `fiatWithdraw()`, `fiatDeposit()`, and other body-based requests.

### Root Cause
The signature string was constructed by directly concatenating query and body parameters without an `&`, resulting in malformed payloads.

### Solution
Ensure proper separator handling when generating the signature.

### Result
- Correct signature generation for fiat and other body-based endpoints
- No API changes
- Existing tests validate the fix
