### PR TITLE
fix: add missing GTE_GTC to NewAlgoOrderTimeInForceEnum

### DIFF
--- a/clients/derivatives-trading-usds-futures/src/rest-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/rest-api/modules/trade-api.ts
@@ -5244,6 +5244,7 @@ export enum NewAlgoOrderTimeInForceEnum {
     GTX = 'GTX',
     GTD = 'GTD',
     RPI = 'RPI',
+    GTE_GTC = 'GTE_GTC',
 }
 
 export enum NewAlgoOrderWorkingTypeEnum {

--- a/clients/derivatives-trading-usds-futures/src/websocket-api/modules/trade-api.ts
+++ b/clients/derivatives-trading-usds-futures/src/websocket-api/modules/trade-api.ts
@@ -1096,6 +1096,7 @@ export enum NewAlgoOrderTimeInForceEnum {
     GTX = 'GTX',
     GTD = 'GTD',
     RPI = 'RPI',
+    GTE_GTC = 'GTE_GTC',
 }
 
 export enum NewAlgoOrderWorkingTypeEnum {


### PR DESCRIPTION
So I added the missing enum value in both the REST and WebSocket API modules to keep things consistent this makes sure developers can use `GTE_GTC` directly without needing any workarounds.