### PR TITLE
fix(common): add missing Portfolio Margin testnet URL constants

### DIFF
--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -57,8 +57,12 @@ export const DERIVATIVES_TRADING_OPTIONS_WS_STREAMS_TESTNET_URL = 'wss://fstream
 
 // Derivatives Trading (Portfolio Margin) constants
 export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_PROD_URL = 'https://papi.binance.com';
+export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_TESTNET_URL =
+    'https://testnet.binancefuture.com';
 export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_WS_STREAMS_PROD_URL =
     'wss://fstream.binance.com/pm';
+export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_WS_STREAMS_TESTNET_URL =
+    'wss://fstream.binancefuture.com/pm';
 
 // Derivatives Trading (Portfolio Margin Pro) constants
 export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_PRO_REST_API_PROD_URL = 'https://api.binance.com';


### PR DESCRIPTION
## Problem

`@binance/derivatives-trading-portfolio-margin` (e.g. v14.0.3) imports two constants from `@binance/common`:

- `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_TESTNET_URL`
- `DERIVATIVES_TRADING_PORTFOLIO_MARGIN_WS_STREAMS_TESTNET_URL`

However, these constants are **not defined** in `@binance/common` (latest `2.4.0`). As a result, simply importing the portfolio-margin package throws at load time:

```
SyntaxError: The requested module '@binance/common' does not provide an
export named 'DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_TESTNET_URL'
```

This makes the published `@binance/derivatives-trading-portfolio-margin` package (and any tool depending on it, e.g. `@binance/binance-cli`) completely unusable — the CLI crashes on startup before running any command.

## Fix

Add the two missing constants to `common/src/constants.ts`, following the existing derivatives testnet convention and the values documented in the portfolio-margin client README (`/papi/*` endpoints on the Futures Testnet `https://testnet.binancefuture.com/`):

```ts
export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_REST_API_TESTNET_URL =
    'https://testnet.binancefuture.com';
export const DERIVATIVES_TRADING_PORTFOLIO_MARGIN_WS_STREAMS_TESTNET_URL =
    'wss://fstream.binancefuture.com/pm';
```

`common/src/index.ts` already re-exports everything from `constants`, so no other change is needed. A new `@binance/common` release would then unblock the portfolio-margin package.

## Notes

- REST testnet value matches the other derivatives clients (`testnet.binancefuture.com`) and the portfolio-margin README.
- WS streams testnet mirrors the prod URL (`wss://fstream.binance.com/pm`) with the testnet host, consistent with the USDS/Options WS testnet convention.